### PR TITLE
Check clippy in a separate workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,24 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{matrix.rust}}
+      - name: Run tests
+        run: |
+          cargo test --verbose
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
           components: clippy
       - name: Check clippy
         run: |
           cargo clippy --all-targets --all-features -- -D warnings
-      - name: Run tests
-        run: |
-          cargo test --verbose
 
   rustfmt:
     name: rustfmt


### PR DESCRIPTION
Run the clippy job in a seperate workflow job that only runs on ubuntu-latest with stable rust, instead of all platforms and rust versions. This will speed up the ci.